### PR TITLE
Allow specifying database location (resolves #10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,5 +329,9 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 
-# Excel files
-*.xlsx
+#######################################
+# Custom Exclusions
+#######################################
+
+# Directories
+PrivateFiles/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4 (2020-04-12)
+### New Features:
+- Added command-line option for `--database=FILE` to support for custom Plex installations. [#10](https://github.com/kmahon37/plex-dvr-waker/issues/10)
+
 ## 1.1.3 (2020-02-08)
 ### Fixed bugs:
 - Fixed loading EPG info to support xmltv providers [#8](https://github.com/kmahon37/plex-dvr-waker/issues/8)

--- a/CmdLine/ProgramOptions.cs
+++ b/CmdLine/ProgramOptions.cs
@@ -4,6 +4,11 @@ namespace PlexDvrWaker.CmdLine
 {
     internal class ProgramOptions
     {
+        [Option("database",
+            MetaValue = "FILE",
+            HelpText = @"(Default: <Plex local application data path or %LOCALAPPDATA%>\Plex Media Server\Plug-in Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for custom Plex installations.")]
+        public string LibraryDatabaseFileName { get; set; }
+
         [Option("verbose",
             HelpText = "Prints all messages to standard output.")]
         public bool Verbose { get; set; }

--- a/Common/Logger.cs
+++ b/Common/Logger.cs
@@ -41,10 +41,10 @@ namespace PlexDvrWaker.Common
 
         public static void LogInformation(string message, bool showMessageToUser)
         {
-            var prefix = DateTime.Now.ToString("s");
+            var dateNow = DateTime.Now;
 
-            LogToFile($"{prefix}\t{ProcessId.ToString().PadLeft(10)}\t{message}");
-            LogToConsole($"{prefix}\t{message}", (msg) =>
+            LogToFile(message, dateNow);
+            LogToConsole($"{dateNow:s}\t{message}", (msg) =>
             {
                 if (Verbose)
                 {
@@ -62,9 +62,7 @@ namespace PlexDvrWaker.Common
 
         public static void LogError(string message)
         {
-            var prefix = DateTime.Now.ToString("s");
-
-            LogToFile($"{prefix}\t{ProcessId.ToString().PadLeft(10)}\tERROR: {message}");
+            LogToFile($"ERROR: {message}");
             LogToConsole($"ERROR: {message}", (msg) =>
             {
                 LogErrorToConsole(msg);
@@ -96,10 +94,17 @@ namespace PlexDvrWaker.Common
 
         public static void LogToFile(string message)
         {
+            LogToFile(message, null);
+        }
+
+        private static void LogToFile(string message, DateTime? dateTime = null)
+        {
+            var logFileMsg = $"{dateTime ?? DateTime.Now:s}\t{ProcessId,10}\t{message}";
+
             lock (LOG_FILE_LOCK)
             {
                 RollLogFileIfNeeded();
-                File.AppendAllLines(LogFileName, new[] { message });
+                File.AppendAllLines(LogFileName, new[] { logFileMsg });
             }
         }
 

--- a/Plex/Contracts/ScheduledMaintenance.cs
+++ b/Plex/Contracts/ScheduledMaintenance.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace PlexDvrWaker.Plex
+namespace PlexDvrWaker.Plex.Contracts
 {
     internal class ScheduledMaintenance
     {

--- a/Plex/Contracts/ScheduledRecording.cs
+++ b/Plex/Contracts/ScheduledRecording.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace PlexDvrWaker.Plex
+namespace PlexDvrWaker.Plex.Contracts
 {
     internal class ScheduledRecording
     {

--- a/Plex/DataAdapter.cs
+++ b/Plex/DataAdapter.cs
@@ -1,4 +1,5 @@
 using PlexDvrWaker.Common;
+using PlexDvrWaker.Plex.Contracts;
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;

--- a/Plex/Settings.cs
+++ b/Plex/Settings.cs
@@ -18,7 +18,8 @@ namespace PlexDvrWaker.Plex
         public static int ButlerEndHour { get; } = GetRegistryValue("ButlerEndHour", 5);
 
         private static string _libraryDatabaseFileName;
-        public static string LibraryDatabaseFileName {
+        public static string LibraryDatabaseFileName
+        {
             get
             {
                 if (string.IsNullOrWhiteSpace(_libraryDatabaseFileName))
@@ -34,7 +35,19 @@ namespace PlexDvrWaker.Plex
 
                 return _libraryDatabaseFileName;
             }
+            set
+            {
+                if (!string.IsNullOrWhiteSpace(_libraryDatabaseFileName))
+                {
+                    throw new InvalidOperationException("The library database file name cannot be set after the default has already been set.");
+                }
+
+                _libraryDatabaseFileName = value;
+                LibraryDatabaseIsOverridden = true;
+            }
         }
+
+        public static bool LibraryDatabaseIsOverridden { get; private set; } = false;
 
         private static T GetRegistryValue<T>(string keyName, T defaultValue)
         {

--- a/PlexDvrWaker.csproj
+++ b/PlexDvrWaker.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <Authors>Kris Mahon</Authors>
     <Title>Plex DVR Waker</Title>
-    <Version>1.1.3</Version>
+    <Version>1.1.4</Version>
     <Copyright>Copyright (C) 2020 Kris Mahon</Copyright>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/README.md
+++ b/README.md
@@ -53,11 +53,12 @@ dotnet PlexDvrWaker.dll add-task --sync
 - [Custom Plex Installations](#cmdline-custom)
 
 ### Displaying help <a name="cmdline-help"></a>
-The main help screen displays the top-level help for the available commands.  You can also view specific detailed help for each command by using the syntax: `dotnet PlexDvrWaker.dll help <command_name>`.
+The main help screen displays the top-level help for the available commands.  You can also view specific detailed help for each command by using the syntax: `dotnet PlexDvrWaker.dll help <command_name>` or `dotnet PlexDvrWaker.dll <command_name> --help`.
 
 *Usage:*
 ```
 dotnet PlexDvrWaker.dll help [add-task|list|monitor]
+dotnet PlexDvrWaker.dll [add-task|list|monitor] --help
 ```
 
 *Example output:*
@@ -199,7 +200,7 @@ Press any key to stop monitoring
 ### Custom Plex Installations <a name="cmdline-custom"></a>
 If you have a custom Plex installation, such as if you installed Plex under a different user/service account, then you may need to specify the `--database` option when running commands.  With this option, you will need to specify the full path and file name to your database file in the custom location (ie: `--database="C:\My Custom Folder\custom2\com.plexapp.plugins.library.db"`).
 
-By default, Plex DVR Waker tries to load Plex's local application data storage path from the registry (`Computer\HKEY_CURRENT_USER\Software\Plex, Inc.\Plex Media Server\LocalAppDataPath`) if it exists (Note: This is controlled via an Advanced setting in Plex under "Settings > General").  Otherwise, Plex DVR Waker will fallback onto Plex's default local application data storage path (`%LOCALAPPDATA%` which usually corresponds to `C:\Users\<USER_NAME>\AppData\Local\`).  Once the storage path is identified, it then tries to find the Plex library database under that folder (`...\Plex Media Server\Plug-in Support\Databases\com.plexapp.plugins.library.db`).
+By default, Plex DVR Waker tries to load Plex's local application data storage path from the registry (`Computer\HKEY_CURRENT_USER\Software\Plex, Inc.\Plex Media Server\LocalAppDataPath`) if it exists (Note: This is controlled via an Advanced setting in Plex under "Settings > General").  Otherwise, Plex DVR Waker will fallback onto Plex's default local application data storage path (`%LOCALAPPDATA%` which usually corresponds to `C:\Users\<USER_NAME>\AppData\Local\`).  Once the storage path is identified, it then tries to find the Plex library database file under that folder (`...\Plex Media Server\Plug-in Support\Databases\com.plexapp.plugins.library.db`).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Plex DVR Waker is a simple command-line tool for waking the computer before the 
 > _NOTE: It does *not* support any other Plex "advanced record options" (ie: Prefer HD, Replace lower resolution items, etc)._
 
 ## Requirements
+- Plex Media Server for Windows ([download from Plex](https://www.plex.tv/media-server-downloads/))
 - Windows 7/8/10
 - Windows Task Scheduler
 - Windows .NET Core 2.2+ Runtime ([download from Microsoft](https://dotnet.microsoft.com/download))
@@ -49,6 +50,7 @@ dotnet PlexDvrWaker.dll add-task --sync
 - [Adding a wakeup, sync, or monitor task](#cmdline-add-task)
 - [Display upcoming scheduled recordings](#cmdline-list)
 - [Monitor Plex library database (interactive mode)](#cmdline-monitor)
+- [Custom Plex Installations](#cmdline-custom)
 
 ### Displaying help <a name="cmdline-help"></a>
 The main help screen displays the top-level help for the available commands.  You can also view specific detailed help for each command by using the syntax: `dotnet PlexDvrWaker.dll help <command_name>`.
@@ -85,9 +87,9 @@ The `monitor` task will watch the Plex library database files for changes and al
 
 *Usage:*
 ```
-dotnet PlexDvrWaker.dll add-task --wakeup [--verbose]
-dotnet PlexDvrWaker.dll add-task --sync [--interval=MINUTES] [--verbose]
-dotnet PlexDvrWaker.dll add-task --monitor [--debounce=SECONDS] [--verbose]
+dotnet PlexDvrWaker.dll add-task --wakeup [--database=FILE] [--verbose]
+dotnet PlexDvrWaker.dll add-task --sync [--interval=MINUTES] [--database=FILE] [--verbose]
+dotnet PlexDvrWaker.dll add-task --monitor [--debounce=SECONDS] [--database=FILE] [--verbose]
 ```
 
 *Arguments:*
@@ -111,6 +113,10 @@ dotnet PlexDvrWaker.dll add-task --monitor [--debounce=SECONDS] [--verbose]
                         short time, upon the first change it will wait the specified number of seconds
                         before it updates the Task Scheduler 'wakeup' task with the next scheduled recording
                         time or Plex maintenance time.
+
+  --database=FILE       (Default: <Plex local application data path or %LOCALAPPDATA%>\Plex Media Server\Plug-in
+                        Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for
+                        custom Plex installations.
 
   --verbose             Prints all messages to standard output.
 ```
@@ -136,14 +142,18 @@ You can display the upcoming scheduled recordings and Plex maintenance that is r
 
 *Usage:*
 ```
-dotnet PlexDvrWaker.dll list [--maintenance] [--verbose]
+dotnet PlexDvrWaker.dll list [--maintenance] [--database=FILE] [--verbose]
 ```
 
 *Arguments:*
 ```
-  --maintenance    Prints the next Plex maintenance time to standard output.
+  --maintenance      Prints the next Plex maintenance time to standard output.
 
-  --verbose        Prints all messages to standard output.
+  --database=FILE    (Default: <Plex local application data path or %LOCALAPPDATA%>\Plex Media Server\Plug-in
+                     Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for custom
+                     Plex installations.
+
+  --verbose          Prints all messages to standard output.
 ```
 
 *Example output (`--maintenance`):*
@@ -159,11 +169,11 @@ Next scheduled maintenance time is 9/15/2019 2:00:00 AM to 9/15/2019 3:00:00 AM
 ```
 
 ### Monitor Plex library database (interactive mode) <a name="cmdline-monitor"></a>
-You can also monitor the Plex library database for changes and automatically refresh the next wakeup time.  This is what is run hidden in the background when you run the `add-task --monitor` command.  If you want to, you can also run it in a foreground/interactive console window.  When run with the `verbose` option, this allows you to see how frequently your Plex library database is changing.  Based on the frequency, you may want to adjust the `debouce` setting accordingly.
+You can also monitor the Plex library database for changes and automatically refresh the next wakeup time.  This is what is run hidden in the background when you run the `add-task --monitor` command.  If you want to, you can also run it in a foreground/interactive console window.  When run with the `--verbose` option, this allows you to see how frequently your Plex library database is changing.  Based on the frequency, you may want to adjust the `--debouce` setting accordingly.
 
 *Usage:*
 ```
-dotnet PlexDvrWaker.dll monitor [--debounce=SECONDS] [--verbose]
+dotnet PlexDvrWaker.dll monitor [--debounce=SECONDS] [--database=FILE] [--verbose]
 ```
 
 *Arguments:*
@@ -173,6 +183,10 @@ dotnet PlexDvrWaker.dll monitor [--debounce=SECONDS] [--verbose]
                         updates the Task Scheduler 'wakeup' task with the next scheduled recording time
                         or Plex maintenance time. (Minimum: 1 second)
 
+  --database=FILE       (Default: <Plex local application data path or %LOCALAPPDATA%>\Plex Media Server\Plug-in
+                        Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for
+                        custom Plex installations.
+
   --verbose             Prints all messages to standard output.
 ```
 
@@ -181,6 +195,11 @@ dotnet PlexDvrWaker.dll monitor [--debounce=SECONDS] [--verbose]
 Started monitoring the Plex library database
 Press any key to stop monitoring
 ```
+
+### Custom Plex Installations <a name="cmdline-custom"></a>
+If you have a custom Plex installation, such as if you installed Plex under a different user/service account, then you may need to specify the `--database` option when running commands.  With this option, you will need to specify the full path and file name to your database file in the custom location (ie: `--database="C:\My Custom Folder\custom2\com.plexapp.plugins.library.db"`).
+
+By default, Plex DVR Waker tries to load Plex's local application data storage path from the registry (`Computer\HKEY_CURRENT_USER\Software\Plex, Inc.\Plex Media Server\LocalAppDataPath`) if it exists (Note: This is controlled via an Advanced setting in Plex under "Settings > General").  Otherwise, Plex DVR Waker will fallback onto Plex's default local application data storage path (`%LOCALAPPDATA%` which usually corresponds to `C:\Users\<USER_NAME>\AppData\Local\`).  Once the storage path is identified, it then tries to find the Plex library database under that folder (`...\Plex Media Server\Plug-in Support\Databases\com.plexapp.plugins.library.db`).
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -150,8 +150,8 @@ dotnet PlexDvrWaker.dll list [--maintenance] [--database=FILE] [--verbose]
   --maintenance      Prints the next Plex maintenance time to standard output.
 
   --database=FILE    (Default: <Plex local application data path or %LOCALAPPDATA%>\Plex Media Server\Plug-in
-                     Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for custom
-                     Plex installations.
+                     Support\Databases\com.plexapp.plugins.library.db) The Plex library database file to use for
+                     custom Plex installations.
 
   --verbose          Prints all messages to standard output.
 ```


### PR DESCRIPTION
This adds a new command line option `--database=FILE` for specifying a custom location for the Plex library database file.